### PR TITLE
fix: release workflown for getting chart version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: "Hub chart v${{ steps.tag_version.outputs.CHART_VERSION }}"
+          name: ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
           prerelease: ${{ contains(steps.chart_version.outputs.CHART_VERSION, '-') }}
         if: steps.tag_exists.outputs.TAG_EXISTS == 'false'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Get chart version
         id: chart_version
         run: |
-          echo "CHART_VERSION=$(cat chart/traefik-hub/Chart.yaml | awk -F"[ ',]+" '/version:/{print $2}')" >> $GITHUB_OUTPUT
+          echo "CHART_VERSION=$(cat traefik-hub/Chart.yaml | awk -F"[ ',]+" '/version:/{print $2}')" >> $GITHUB_OUTPUT
 
       - name: Check if tag exists
         id: tag_exists

--- a/traefik-hub/Chart.yaml
+++ b/traefik-hub/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: traefik-hub
 description: Traefik Hub Ingress Controller
 type: application
-version: 1.0.4
+version: 1.0.5
 # renovate: image=ghcr.io/traefik/traefik-hub
 appVersion: v2.1.0
 kubeVersion: ">=1.16.0-0"


### PR DESCRIPTION
### What does this PR do?

Two fixes on `release` workflow
- fix getting chart version
- fix release name

### Motivation

Publish release with expected name and version
