### PR TITLE
fix: admission to avoid tls: bad certificate

### DIFF
--- a/traefik-hub/templates/admission-controller.yaml
+++ b/traefik-hub/templates/admission-controller.yaml
@@ -1,5 +1,5 @@
 {{- $altNames := list ( printf "admission.%s.svc" .Release.Namespace ) -}}
-{{- $cert := genSelfSignedCert ( printf "admission.%s.svc" .Release.Namespace ) nil $altNames 365 -}}
+{{- $cert := genSelfSignedCert ( printf "admission.%s.svc" .Release.Namespace ) (list) $altNames 365 -}}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
### What does this PR do?

Fixes `http: TLS handshake error from 10.42.0.1:35050: remote error: tls: bad certificate` error

### Motivation

Have the admission webhook working

### More

- [x] Yes, I updated the tests accordingly
- [x] Yes, I ran `make test` and all the tests passed

