### PR TITLE
fix: don't set resources limits and requests by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+# vim temporary files
+*.swp
+*.swo

--- a/traefik-hub/templates/deployment.yaml
+++ b/traefik-hub/templates/deployment.yaml
@@ -72,13 +72,19 @@ spec:
             {{- with .Values.additionalArguments }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.resources }}
           resources:
+            {{- with .requests }}
             requests:
-              memory: {{.Values.resources.requests.memory }}
-              cpu: {{.Values.resources.requests.cpu }}
+              memory: {{ .memory }}
+              cpu: {{ .cpu }}
+            {{- end }}
+            {{- with .limits }}
             limits:
-              memory: {{.Values.resources.limits.memory }}
-              cpu: {{.Values.resources.limits.cpu }}
+              memory: {{ .memory }}
+              cpu: {{ .cpu }}
+            {{- end }}
+          {{- end }}
           env:
             # TODO: remove this when new traefik-hub version will be released
             - name: HUB_EXPERIMENTAL_INGRESS_CONTROLLER_MODE

--- a/traefik-hub/tests/deployment_test.yaml
+++ b/traefik-hub/tests/deployment_test.yaml
@@ -30,7 +30,13 @@ tests:
       - equal:
           path: metadata.namespace
           value: test
-  - it: should set resources
+  - it: should not set resources by default
+    release:
+      namespace: test
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+  - it: should set resources when specified
     release:
       namespace: test
     set:

--- a/traefik-hub/values.yaml
+++ b/traefik-hub/values.yaml
@@ -7,13 +7,14 @@ priorityClassName: ""
 image: ghcr.io/traefik/traefik-hub:{{ .Chart.AppVersion }}
 serviceAccountName: traefik-hub-controller
 
-resources:
-  requests:
-    memory: 64Mi
-    cpu: 50m
-  limits:
-    memory: 128Mi
-    cpu: 80m
+
+resources: {}
+#  requests:
+#    memory: 64Mi
+#    cpu: 250m
+#  limits:
+#    memory: 128Mi
+#    cpu: 500m
 
 # configure your hubToken with --set hubTokenSecretName=mySecret
 # kubectl create secret generic mySecret --namespace traefik --from-literal=token=xxx


### PR DESCRIPTION
### What does this PR do?

1. Remove defaults on resources `limits` and `requests`
2. Add temp vim files to `.gitignore`

### Motivation

When testing Traefik Hub, there is no interest in this resources tuning
When using Traefik Hub on a production env, the admin should decide if and what `resources` parameters are needed

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

