### PR TITLE
fix: add missing kustomization.yaml for upgrade

### DIFF
--- a/traefik-hub/crds/kustomization.yaml
+++ b/traefik-hub/crds/kustomization.yaml
@@ -1,0 +1,32 @@
+---
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- hub.traefik.io_accesscontrolpolicies.yaml
+- hub.traefik.io_apiaccesses.yaml
+- hub.traefik.io_apicollections.yaml
+- hub.traefik.io_apigateways.yaml
+- hub.traefik.io_apiportals.yaml
+- hub.traefik.io_apiratelimits.yaml
+- hub.traefik.io_apis.yaml
+- hub.traefik.io_apiversions.yaml
+- hub.traefik.io_edgeingresses.yaml
+- hub.traefik.io_ingressclasses.yaml
+- traefik.containo.us_ingressroutes.yaml
+- traefik.containo.us_ingressroutetcps.yaml
+- traefik.containo.us_ingressrouteudps.yaml
+- traefik.containo.us_middlewares.yaml
+- traefik.containo.us_middlewaretcps.yaml
+- traefik.containo.us_serverstransports.yaml
+- traefik.containo.us_tlsoptions.yaml
+- traefik.containo.us_tlsstores.yaml
+- traefik.containo.us_traefikservices.yaml
+- traefik.io_ingressroutes.yaml
+- traefik.io_ingressroutetcps.yaml
+- traefik.io_ingressrouteudps.yaml
+- traefik.io_middlewares.yaml
+- traefik.io_middlewaretcps.yaml
+- traefik.io_serverstransports.yaml
+- traefik.io_tlsoptions.yaml
+- traefik.io_tlsstores.yaml
+- traefik.io_traefikservices.yaml


### PR DESCRIPTION
### What does this PR do?

Add a `kustomization.yaml` in CRDs.
This file is already ignored in `.helmignore`.

### Motivation

It was missed and it's needed to upgrade CRDs when using Helm.