### PR TITLE
feat: k8s providers customization

### DIFF
--- a/traefik-hub/templates/deployment.yaml
+++ b/traefik-hub/templates/deployment.yaml
@@ -80,6 +80,56 @@ spec:
             - --providers.kubernetesCRD.allowExternalNameServices=true
             - --providers.kubernetesIngress.allowEmptyServices=true
             - --providers.kubernetesIngress.allowExternalNameServices=true
+            {{- with .Values.providers }}
+            {{- with .kubernetesCRD.endpoint }}
+            - --providers.kubernetescrd.endpoint="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesCRD.token }}
+            - --providers.kubernetescrd.token="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesCRD.certAuthFilePath }}
+            - --providers.kubernetescrd.certauthfilepath="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesCRD.namespaces }}
+            - --providers.kubernetescrd.namespaces="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesCRD.labelselector }}
+            - --providers.kubernetescrd.labelselector="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesCRD.throttleDuration }}
+            - --providers.kubernetescrd.throttleduration="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.endpoint }}
+            - --providers.kubernetesingress.endpoint="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.token }}
+            - --providers.kubernetesingress.token="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.certAuthFilePath }}
+            - --providers.kubernetesingress.certauthfilepath="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.namespaces }}
+            - --providers.kubernetesingress.namespaces="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.labelselector }}
+            - --providers.kubernetesingress.labelselector="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.ingressClass }}
+            - --providers.kubernetesingress.ingressclass="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.ingressEndpoint.hostname }}
+            - --providers.kubernetesingress.ingressendpoint.hostname="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.ingressEndpoint.ip }}
+            - --providers.kubernetesingress.ingressendpoint.ip="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.ingressEndpoint.publishedService }}
+            - --providers.kubernetesingress.ingressendpoint.publishedservice="{{ . }}"
+            {{- end }}
+            {{- with .kubernetesIngress.throttleDuration }}
+            - --providers.kubernetesingress.throttleduration="{{ . }}"
+            {{- end }}
+            {{- end }}
             {{- with $additionnalArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/traefik-hub/tests/deployment_test.yaml
+++ b/traefik-hub/tests/deployment_test.yaml
@@ -160,3 +160,75 @@ tests:
       - equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: regcred
+  - it: should set providers settings
+    set:
+      providers:
+        kubernetesCRD:
+          endpoint: "local.tld"
+          token: "xxx"
+          certAuthFilePath: "/var/crds.pem"
+          namespaces: "ns1,ns2"
+          labelselector: "foo=bar"
+          ingressClass: "crd"
+          throttleDuration: "10s"
+        kubernetesIngress:
+          endpoint: "local2.tld"
+          token: "yyy"
+          certAuthFilePath: "/var/ings.pem"
+          namespaces: "ns3,ns4"
+          labelselector: "bar=foo"
+          ingressClass: "ing"
+          ingressEndpoint:
+            hostname: "ing.tld"
+            ip: "1.2.3.4"
+            publishedService: "ns/svc"
+          throttleDuration: "10h"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetescrd.endpoint="local.tld"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetescrd.token="xxx"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetescrd.certauthfilepath="/var/crds.pem"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetescrd.namespaces="ns1,ns2"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetescrd.labelselector="foo=bar"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetescrd.throttleduration="10s"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.endpoint="local2.tld"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.token="yyy"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.certauthfilepath="/var/ings.pem"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.namespaces="ns3,ns4"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.labelselector="bar=foo"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.ingressclass="ing"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.ingressendpoint.hostname="ing.tld"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.ingressendpoint.ip="1.2.3.4"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.ingressendpoint.publishedservice="ns/svc"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --providers.kubernetesingress.throttleduration="10h"

--- a/traefik-hub/values.yaml
+++ b/traefik-hub/values.yaml
@@ -19,28 +19,6 @@ resources: {}
 #    memory: 128Mi
 #    cpu: 500m
 
-providers:
-  kubernetesCRD:
-    endpoint:
-    token:
-    certAuthFilePath:
-    namespaces: []
-    labelselector:
-    ingressClass:
-    throttleDuration:
-  kubernetesIngress:
-    endpoint:
-    token:
-    certAuthFilePath:
-    namespaces: []
-    labelselector:
-    ingressClass:
-    ingressEndpoint:
-      hostname:
-      ip:
-      publishedService:
-    throttleDuration:
-
 # configure your hubToken with --set hubTokenSecretName=mySecret
 # kubectl create secret generic mySecret --namespace traefik --from-literal=token=xxx
 hubTokenSecretName: "hub-agent-token"
@@ -65,8 +43,36 @@ service:
       name: websecure
       targetPort: websecure
 
-# use it to load plugins
+## use it to load plugins
 plugins: []
 # - name: crowdsec-bouncer-traefik-plugin
 #   moduleName: github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
 #   version: v1.1.15
+
+## Customize Traefik Providers
+##  - https://doc.traefik.io/traefik/providers/kubernetes-crd
+##  - https://doc.traefik.io/traefik/providers/kubernetes-ingress
+## On Traefik Hub, `allowCrossNamespace`, `allowEmptyServices` 
+## and `allowExternalNameServices` are set to true.
+providers:
+  kubernetesCRD:
+    endpoint:
+    token:
+    certAuthFilePath:
+    namespaces:
+    labelselector:
+    ingressClass:
+    throttleDuration:
+  kubernetesIngress:
+    endpoint:
+    token:
+    certAuthFilePath:
+    namespaces:
+    labelselector:
+    ingressClass:
+    ingressEndpoint:
+      hostname:
+      ip:
+      publishedService:
+    throttleDuration:
+

--- a/traefik-hub/values.yaml
+++ b/traefik-hub/values.yaml
@@ -19,6 +19,28 @@ resources: {}
 #    memory: 128Mi
 #    cpu: 500m
 
+providers:
+  kubernetesCRD:
+    endpoint:
+    token:
+    certAuthFilePath:
+    namespaces: []
+    labelselector:
+    ingressClass:
+    throttleDuration:
+  kubernetesIngress:
+    endpoint:
+    token:
+    certAuthFilePath:
+    namespaces: []
+    labelselector:
+    ingressClass:
+    ingressEndpoint:
+      hostname:
+      ip:
+      publishedService:
+    throttleDuration:
+
 # configure your hubToken with --set hubTokenSecretName=mySecret
 # kubectl create secret generic mySecret --namespace traefik --from-literal=token=xxx
 hubTokenSecretName: "hub-agent-token"


### PR DESCRIPTION
### What does this PR do?

Allows to customize Kubernetes CRDs & Kubernetes Ingress providers.
Parameters required for Traefik Hub are enabled by default and cannot be changed.

### Motivation

Some user needs to define settings specific to their environment, like `IngressClass` or others.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

