### PR TITLE
feat: optional HPA

### DIFF
--- a/traefik-hub/templates/deployment.yaml
+++ b/traefik-hub/templates/deployment.yaml
@@ -13,7 +13,9 @@ metadata:
   labels:
   {{- include "traefik-hub.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicas }}
+  {{- with .Values.replicas }}
+  replicas: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
      {{- include "traefik-hub.labelselector" . | nindent 6 }}

--- a/traefik-hub/templates/hpa.yaml
+++ b/traefik-hub/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.maxReplicas }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "traefik-hub.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "traefik-hub.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: traefik
+{{- with .Values.autoscaling }}
+  {{- with .minReplicas }}
+  minReplicas: {{ . }}
+  {{- end }}
+  {{- with .maxReplicas }}
+  maxReplicas: {{ . }}
+  {{- end }}
+  {{- with .metrics }}
+  metrics: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .behavior }}
+  behavior: {{ toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/traefik-hub/tests/hpa_test.yaml
+++ b/traefik-hub/tests/hpa_test.yaml
@@ -1,0 +1,86 @@
+suite: HPA tests
+release:
+  name: traefik-hub
+  namespace: traefik
+templates:
+  - hpa.yaml
+tests:
+  - it: should not render HPA by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render HPA with only maxReplicas set
+    set:
+      autoscaling:
+        maxReplicas: 5
+    asserts:
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - isAPIVersion:
+          of: autoscaling/v2
+      - isNull:
+          path: spec.metrics
+      - isNull:
+          path: spec.behavior
+      - isNull:
+          path: spec.minReplicas
+  - it: should set the namespace
+    release:
+      namespace: test
+    set:
+      autoscaling:
+        maxReplicas: 5
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: test
+  - it: hpa should be customizable
+    set:
+      autoscaling:
+        minReplicas: 2
+        maxReplicas: 5
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 60
+          - type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 60
+        behavior:
+          scaleDown:
+            stabilizationWindowSeconds: 300
+            policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 60
+    asserts:
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 5
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: memory
+              target:
+                type: Utilization
+                averageUtilization: 60
+      - isSubset:
+          path: spec.behavior
+          content:
+            scaleDown:
+              stabilizationWindowSeconds: 300
+              policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 60

--- a/traefik-hub/values.yaml
+++ b/traefik-hub/values.yaml
@@ -1,4 +1,7 @@
-replicas: 1
+## Can be used to set number of Traefik Hub instances
+## When using HPA, keep it empty in order to avoid conflicts
+## between this value and HPA.
+replicas:
 maxSurge: 1
 
 ## On production system, you may want to set it to "system-cluster-critical"
@@ -59,6 +62,14 @@ service:
     - port: 443
       name: websecure
       targetPort: websecure
+
+## Optional HPA on Traefik Hub. Created when required `maxReplicas` is set.
+## See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+autoscaling:
+  minReplicas:
+  maxReplicas:
+  metrics:
+  behavior:
 
 # use it to load plugins
 plugins: []


### PR DESCRIPTION
### What does this PR do?

1. Introduce optional HorizontalPodAutoscaler
2. Move `spec.replicas` of `Deployment` to an optional field, as [it is the case in K8s](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec). It's far better to **not** set `spec.replicas` when using HPA.

### Motivation

It can help on HA or production deployment.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

