### PR TITLE
chore: remove unnecessary env var

### DIFF
--- a/traefik-hub/templates/deployment.yaml
+++ b/traefik-hub/templates/deployment.yaml
@@ -152,9 +152,6 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            # TODO: remove this when new traefik-hub version will be released
-            - name: HUB_EXPERIMENTAL_INGRESS_CONTROLLER_MODE
-              value: "true"
             - name: HUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/traefik-hub/tests/deployment_test.yaml
+++ b/traefik-hub/tests/deployment_test.yaml
@@ -73,12 +73,7 @@ tests:
     asserts:
       - lengthEqual:
           path: spec.template.spec.containers[0].env
-          count: 4
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: HUB_EXPERIMENTAL_INGRESS_CONTROLLER_MODE
-            value: "true"
+          count: 3
       - contains:
           path: spec.template.spec.containers[0].env
           content:


### PR DESCRIPTION
### What does this PR do?

Remove HUB_EXPERIMENTAL_INGRESS_CONTROLLER_MODE env var.

### Motivation

This env var is not necessary since more than 5 months.

### More

- [ ] Yes, I updated the tests accordingly
- [ ] Yes, I ran `make test` and all the tests passed

<!--

HOW TO WRITE A GOOD PULL REQUEST? https://doc.traefik.io/traefik/contributing/submitting-pull-requests/

-->

