### PR TITLE
Fix - Service annotations indent

### DIFF
--- a/traefik-hub/templates/service.yaml
+++ b/traefik-hub/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   annotations:
   {{- with .annotations }}
-  {{ toYaml . | indent 4 }}
+  {{- toYaml . | indent 4 }}
   {{- end }}
 spec:
   type: {{ .type }}

--- a/traefik-hub/templates/service.yaml
+++ b/traefik-hub/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
   annotations:
   {{- with .annotations }}
-  {{- toYaml . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .type }}


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with whitespace not being chomped when adding annotation from the values.
### More

- [ ] Yes, I updated the tests accordingly
- [X] Yes, I ran `make test` and all the tests passed

Adapted the service annotations template nothing to change at the test level
